### PR TITLE
Improve landing redirect speed and add loading screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,29 +2,96 @@
 <html lang="es">
 <head>
   <meta charset="UTF-8" />
-  <meta http-equiv="refresh" content="0; url=index.html">
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
-    <meta name="author" content="maix" />
-    <meta name="description" content="MAIX - Movimento de Arte e Pesquisa Estendida. Bolsa XR LATAM para criadores de realidade estendida na América Latina." />
-    <title>MAIX</title>
-    <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
-  <script>
-    // Espera a que el DOM esté listo
-    window.onload = function () {
-      const userLang = navigator.language || navigator.userLanguage;
+  <meta name="author" content="maix" />
+  <meta name="description" content="MAIX - Movimento de Arte e Pesquisa Estendida. Bolsa XR LATAM para criadores de realidade estendida na América Latina." />
+  <title>MAIX</title>
+  <link rel="icon" type="image/x-icon" href="assets/favicon.ico" />
+  <style>
+    :root {
+      color-scheme: dark;
+    }
 
-      // Redirección según el idioma
-      if (userLang.startsWith('pt')) {
-        window.location.href = 'index-pt.html'; // Versión en portugués
-      } else {
-        window.location.href = 'index-es.html'; // Versión en español por defecto
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      gap: 1.5rem;
+      background: #000;
+      color: #fff;
+      font-family: "Helvetica Neue", Arial, sans-serif;
+      text-align: center;
+      padding: 2rem;
+    }
+
+    .logo {
+      width: min(240px, 80vw);
+      height: auto;
+    }
+
+    .spinner {
+      width: 48px;
+      height: 48px;
+      border: 4px solid rgba(255, 255, 255, 0.2);
+      border-top-color: #fff;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+    }
+
+    @keyframes spin {
+      to {
+        transform: rotate(360deg);
       }
-    };
+    }
+
+    .links {
+      display: flex;
+      gap: 1rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
+
+    .link {
+      color: #fff;
+      text-decoration: none;
+      border: 1px solid rgba(255, 255, 255, 0.4);
+      padding: 0.5rem 1.25rem;
+      border-radius: 999px;
+      transition: background 0.2s ease, color 0.2s ease;
+    }
+
+    .link:focus,
+    .link:hover {
+      background: #fff;
+      color: #000;
+    }
+  </style>
+  <script>
+    (function redirectToLocale() {
+      try {
+        const userLang = (navigator.language || navigator.userLanguage || "").toLowerCase();
+        const target = userLang.startsWith("pt") ? "index-pt.html" : "index-es.html";
+        window.location.replace(target);
+      } catch (error) {
+        console.error("Language redirection failed", error);
+      }
+    })();
   </script>
 </head>
 <body>
-  <img class="img-70 mb-3" src="assets/img/logo_maix.png" alt="Logo del colectivo MAIX: Movimiento de Arte e Investigación Extendida" />
-  <h2 class="text-white-50 mx-auto mt-2 mb-5">Movimiento de Arte e Investigación Extendida</h2>
-  <a class="btn btn-primary" href="#beca">Convocatoria 2025</a>
+  <img class="logo" src="assets/img/logo_maix.png" alt="Logo del colectivo MAIX: Movimiento de Arte e Investigación Extendida" />
+  <div class="spinner" role="status" aria-label="Cargando"></div>
+  <p>Redirigiendo a tu idioma preferido…</p>
+  <div class="links">
+    <a class="link" href="index-es.html">Versión en español</a>
+    <a class="link" href="index-pt.html">Versión em português</a>
+  </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the meta refresh with an immediate locale-based redirect
- introduce a dark loading screen with spinner and fallback language links for manual selection

## Testing
- not run (static content)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691411f848748327a4fc7d2d32d2525f)