### PR TITLE
Use Google Docs Viewer for PDF iframe

### DIFF
--- a/reportes-es.html
+++ b/reportes-es.html
@@ -54,7 +54,7 @@
                 </div>
                 <div class="col-lg-8">
                     <div class="ratio ratio-4x3 border rounded shadow-sm">
-                        <iframe id="pdfViewer" src="assets/pdf/reporte-maix-2023.pdf" title="Visualizador de reportes" allow="fullscreen" allowfullscreen></iframe>
+                        <iframe id="pdfViewer" src="about:blank" title="Visualizador de reportes" allow="fullscreen" allowfullscreen></iframe>
                     </div>
                     <p class="mt-3 text-muted">Para más información sobre los documentos, selecciona uno de la lista.</p>
                 </div>
@@ -82,9 +82,16 @@
                     event.preventDefault();
                     pdfList.querySelectorAll('.list-group-item-action').forEach((node) => node.classList.remove('active'));
                     item.classList.add('active');
-                    pdfViewer.src = item.dataset.pdf;
+                    const pdfUrl = new URL(item.dataset.pdf, window.location.href);
+                    pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
                 }
             });
+
+            const initialPdf = pdfList.querySelector('.list-group-item-action.active');
+            if (initialPdf && initialPdf.dataset && initialPdf.dataset.pdf) {
+                const pdfUrl = new URL(initialPdf.dataset.pdf, window.location.href);
+                pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
+            }
         }
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/reportes-es.html
+++ b/reportes-es.html
@@ -71,7 +71,7 @@
         const pdfViewer = document.getElementById('pdfViewer');
 
         const getPdfUrl = (relativePath) => {
-            const cdnBase = 'https://maix.github.io/';
+            const cdnBase = 'https://maix.art/';
             const baseUrl = window.location.protocol === 'file:' ? cdnBase : `${window.location.origin}/`;
             return new URL(relativePath, baseUrl);
         };

--- a/reportes-es.html
+++ b/reportes-es.html
@@ -70,6 +70,12 @@
         const pdfList = document.getElementById('pdfList');
         const pdfViewer = document.getElementById('pdfViewer');
 
+        const getPdfUrl = (relativePath) => {
+            const cdnBase = 'https://maix.github.io/';
+            const baseUrl = window.location.protocol === 'file:' ? cdnBase : `${window.location.origin}/`;
+            return new URL(relativePath, baseUrl);
+        };
+
         if (pdfList && pdfViewer) {
             pdfList.addEventListener('click', (event) => {
                 const item = event.target.closest('.list-group-item-action');
@@ -82,14 +88,14 @@
                     event.preventDefault();
                     pdfList.querySelectorAll('.list-group-item-action').forEach((node) => node.classList.remove('active'));
                     item.classList.add('active');
-                    const pdfUrl = new URL(item.dataset.pdf, window.location.href);
+                    const pdfUrl = getPdfUrl(item.dataset.pdf);
                     pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
                 }
             });
 
             const initialPdf = pdfList.querySelector('.list-group-item-action.active');
             if (initialPdf && initialPdf.dataset && initialPdf.dataset.pdf) {
-                const pdfUrl = new URL(initialPdf.dataset.pdf, window.location.href);
+                const pdfUrl = getPdfUrl(initialPdf.dataset.pdf);
                 pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
             }
         }

--- a/reportes-es.html
+++ b/reportes-es.html
@@ -54,7 +54,7 @@
                 </div>
                 <div class="col-lg-8">
                     <div class="ratio ratio-4x3 border rounded shadow-sm">
-                        <iframe id="pdfViewer" src="about:blank" title="Visualizador de reportes" allow="fullscreen" allowfullscreen></iframe>
+                        <iframe id="pdfViewer" src="about:blank" title="Visualizador de reportes" loading="lazy"></iframe>
                     </div>
                     <p class="mt-3 text-muted">Para más información sobre los documentos, selecciona uno de la lista.</p>
                 </div>
@@ -89,14 +89,14 @@
                     pdfList.querySelectorAll('.list-group-item-action').forEach((node) => node.classList.remove('active'));
                     item.classList.add('active');
                     const pdfUrl = getPdfUrl(item.dataset.pdf);
-                    pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
+                    pdfViewer.src = `https://drive.google.com/viewerng/viewer?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
                 }
             });
 
             const initialPdf = pdfList.querySelector('.list-group-item-action.active');
             if (initialPdf && initialPdf.dataset && initialPdf.dataset.pdf) {
                 const pdfUrl = getPdfUrl(initialPdf.dataset.pdf);
-                pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
+                pdfViewer.src = `https://drive.google.com/viewerng/viewer?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
             }
         }
     </script>

--- a/reportes-pt.html
+++ b/reportes-pt.html
@@ -54,7 +54,7 @@
                 </div>
                 <div class="col-lg-8">
                     <div class="ratio ratio-4x3 border rounded shadow-sm">
-                        <iframe id="pdfViewer" src="assets/pdf/reporte-maix-2023.pdf" title="Visualizador de relatórios" allow="fullscreen" allowfullscreen></iframe>
+                        <iframe id="pdfViewer" src="about:blank" title="Visualizador de relatórios" allow="fullscreen" allowfullscreen></iframe>
                     </div>
                     <p class="mt-3 text-muted">Caso encontre dificuldades para visualizar, faça o download diretamente da lista.</p>
                 </div>
@@ -82,9 +82,16 @@
                     event.preventDefault();
                     pdfList.querySelectorAll('.list-group-item-action').forEach((node) => node.classList.remove('active'));
                     item.classList.add('active');
-                    pdfViewer.src = item.dataset.pdf;
+                    const pdfUrl = new URL(item.dataset.pdf, window.location.href);
+                    pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
                 }
             });
+
+            const initialPdf = pdfList.querySelector('.list-group-item-action.active');
+            if (initialPdf && initialPdf.dataset && initialPdf.dataset.pdf) {
+                const pdfUrl = new URL(initialPdf.dataset.pdf, window.location.href);
+                pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
+            }
         }
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/reportes-pt.html
+++ b/reportes-pt.html
@@ -71,7 +71,7 @@
         const pdfViewer = document.getElementById('pdfViewer');
 
         const getPdfUrl = (relativePath) => {
-            const cdnBase = 'https://maix.github.io/';
+            const cdnBase = 'https://maix.art/';
             const baseUrl = window.location.protocol === 'file:' ? cdnBase : `${window.location.origin}/`;
             return new URL(relativePath, baseUrl);
         };

--- a/reportes-pt.html
+++ b/reportes-pt.html
@@ -70,6 +70,12 @@
         const pdfList = document.getElementById('pdfList');
         const pdfViewer = document.getElementById('pdfViewer');
 
+        const getPdfUrl = (relativePath) => {
+            const cdnBase = 'https://maix.github.io/';
+            const baseUrl = window.location.protocol === 'file:' ? cdnBase : `${window.location.origin}/`;
+            return new URL(relativePath, baseUrl);
+        };
+
         if (pdfList && pdfViewer) {
             pdfList.addEventListener('click', (event) => {
                 const item = event.target.closest('.list-group-item-action');
@@ -82,14 +88,14 @@
                     event.preventDefault();
                     pdfList.querySelectorAll('.list-group-item-action').forEach((node) => node.classList.remove('active'));
                     item.classList.add('active');
-                    const pdfUrl = new URL(item.dataset.pdf, window.location.href);
+                    const pdfUrl = getPdfUrl(item.dataset.pdf);
                     pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
                 }
             });
 
             const initialPdf = pdfList.querySelector('.list-group-item-action.active');
             if (initialPdf && initialPdf.dataset && initialPdf.dataset.pdf) {
-                const pdfUrl = new URL(initialPdf.dataset.pdf, window.location.href);
+                const pdfUrl = getPdfUrl(initialPdf.dataset.pdf);
                 pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
             }
         }

--- a/reportes-pt.html
+++ b/reportes-pt.html
@@ -54,7 +54,7 @@
                 </div>
                 <div class="col-lg-8">
                     <div class="ratio ratio-4x3 border rounded shadow-sm">
-                        <iframe id="pdfViewer" src="about:blank" title="Visualizador de relatórios" allow="fullscreen" allowfullscreen></iframe>
+                        <iframe id="pdfViewer" src="about:blank" title="Visualizador de relatórios" loading="lazy"></iframe>
                     </div>
                     <p class="mt-3 text-muted">Caso encontre dificuldades para visualizar, faça o download diretamente da lista.</p>
                 </div>
@@ -89,14 +89,14 @@
                     pdfList.querySelectorAll('.list-group-item-action').forEach((node) => node.classList.remove('active'));
                     item.classList.add('active');
                     const pdfUrl = getPdfUrl(item.dataset.pdf);
-                    pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
+                    pdfViewer.src = `https://drive.google.com/viewerng/viewer?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
                 }
             });
 
             const initialPdf = pdfList.querySelector('.list-group-item-action.active');
             if (initialPdf && initialPdf.dataset && initialPdf.dataset.pdf) {
                 const pdfUrl = getPdfUrl(initialPdf.dataset.pdf);
-                pdfViewer.src = `https://docs.google.com/gview?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
+                pdfViewer.src = `https://drive.google.com/viewerng/viewer?embedded=1&url=${encodeURIComponent(pdfUrl.href)}`;
             }
         }
     </script>


### PR DESCRIPTION
## Summary
- update report viewer iframes to load documents through Google Docs Viewer
- build absolute URLs for selected PDFs before loading them in the viewer
- initialize the viewer with the active document using the Google Docs embed URL

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692df11f37d083279c3bb26f8d859f09)